### PR TITLE
feat: dynamically retrieve the latest version of qemu-guest-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Required packages for this guide:
 
 FreeBSD 13 Binary Packages:
 - FreeBSD 13.1 Kernel: [Package](http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/amd64/13.1-RELEASE/kernel.txz)
-- QEMU Guest Agent 8.1.3: [Package](https://pkg.freebsd.org/FreeBSD:13:amd64/latest/All/qemu-guest-agent-8.1.3.pkg)
+- QEMU Guest Agent: [Package](https://pkg.freebsd.org/FreeBSD:13:amd64/latest/All/qemu-guest-agent-9.0.0.pkg)
+  - If the link is dead, replace the package version in the url with the latest one found here: [Package](https://ports.freebsd.org/cgi/ports.cgi?query=qemu-guest-agent&stype=all&sektion=all)
 
 ## Manual Installation
 

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,8 @@ trap 'echo "An error occurred. Exiting..." >&2' ERR
 
 # Variables
 freebsd13_kernel="http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/amd64/13.1-RELEASE/kernel.txz"
-freebsd13_qga_pkg="https://pkg.freebsd.org/FreeBSD:13:amd64/latest/All/qemu-guest-agent-8.1.3.pkg"
+freebsd13_qga_pkg_version=$(curl -s "https://ports.freebsd.org/cgi/ports.cgi?query=qemu-guest-agent&stype=all&sektion=all" | grep -oE 'qemu-guest-agent-[0-9]+(\.[0-9]+)*(_[0-9]+)*' | head -1)
+freebsd13_qga_pkg="https://pkg.freebsd.org/FreeBSD:13:amd64/latest/All/${freebsd13_qga_pkg_version}.pkg"
 qga_backup_dir="/root/qga_backup"
 
 # Download FreeBSD 13.1 kernel.txz and extract virtio_console.ko driver to /boot/kernel

--- a/install_qemu_guest_agent_on_truenas.yml
+++ b/install_qemu_guest_agent_on_truenas.yml
@@ -14,15 +14,22 @@
   hosts: working_group
   gather_facts: true
   remote_user: root
-  vars:
-    # ansible_python_interpreter: /usr/bin/python
-    ansible_ssh_port: 22
-    ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
-    freebsd13_kernel: "http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/amd64/13.1-RELEASE/kernel.txz"
-    freebsd13_qga_pkg: "https://pkg.freebsd.org/FreeBSD:13:amd64/latest/All/qemu-guest-agent-8.1.3.pkg"
-    qga_backup_dir: "/root/qga_backup"
 
   tasks:
+
+    - name: Get qemu-guest-agent version
+      ansible.builtin.shell: curl -s "https://ports.freebsd.org/cgi/ports.cgi?query=qemu-guest-agent&stype=all&sektion=all" | grep -oE 'qemu-guest-agent-[0-9]+(\.[0-9]+)*(_[0-9]+)*' | head -1
+      register: freebsd13_qga_pkg_version
+
+    - name: Define variables
+      ansible.builtin.set_fact:
+        # ansible_python_interpreter: /usr/bin/python
+        ansible_ssh_port: 22
+        ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+        freebsd13_kernel: "http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/amd64/13.1-RELEASE/kernel.txz"
+        freebsd13_qga_pkg: "https://pkg.freebsd.org/FreeBSD:13:amd64/latest/All/{{ freebsd13_qga_pkg_version.stdout }}.pkg"
+        qga_backup_dir: "/root/qga_backup"
+
     - name: Download FreeBSD 13.1 kernel.txz to /tmp
       ansible.builtin.get_url:
         url: "{{ freebsd13_kernel }}"


### PR DESCRIPTION
Automatically retrieves the version found on https://ports.freebsd.org/cgi/ports.cgi?query=qemu-guest-agent&stype=all&sektion=all.