### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ trap 'echo "An error occurred. Exiting..." >&2' ERR
 
 # Variables
 freebsd13_kernel="http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/amd64/13.1-RELEASE/kernel.txz"
-freebsd13_qga_pkg="https://pkg.freebsd.org/FreeBSD:13:amd64/latest/All/qemu-guest-agent-8.1.3.pkg"
+freebsd13_qga_pkg="https://pkg.freebsd.org/FreeBSD:13:amd64/latest/All/qemu-guest-agent-9.0.1.pkg"
 qga_backup_dir="/root/qga_backup"
 
 # Download FreeBSD 13.1 kernel.txz and extract virtio_console.ko driver to /boot/kernel


### PR DESCRIPTION
Version 8.1.3 of qemu-guest-agent is no longer available, the link returns 404 - not found. Currently available version for FreeBSD 13 is 9.0.1, see https://pkgs.org/download/qemu-guest-agent